### PR TITLE
feat: Use conda-forge cross-compilation to improve the build process

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,21 +14,18 @@ source:
     - 0002-Patch-fastjet-contrib-Makefile.in.patch
 
 build:
-  number: 4
+  number: 5
   skip: true  # [not linux]
   script:
-    # Use 'python -m build' to build a wheel first to avoid having the overlinking
-    # check fail by looking in the wrong CPython build_artifacts directory.
-    # It is unclear if this is something that conda-forge should know how to avoid
-    # or if this could be fixed by improvements in the fastjet build system.
-    - {{ PYTHON }} -m build --no-isolation .
-    - {{ PYTHON }} -m pip install --verbose --verbose ./dist/fastjet-*.whl
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib("c") }}
+    - cross-python_{{ target_platform }}    # [build_platform != target_platform]
+    - python                                # [build_platform != target_platform]
     - autoconf
     - automake
     - libtool
@@ -36,7 +33,6 @@ requirements:
     - patch
     - swig
   host:
-    - python-build  # see comment in build script section
     - cgal-cpp  # headers and CGALv5
     - gmp  # shared library
     - pip


### PR DESCRIPTION
* Use the cross-compilation selector, '[build_platform != target_platform]', to simplify the build process by just doing a pip install.
   - c.f. https://conda-forge.org/docs/maintainer/knowledge_base/#details-about-cross-compiled-python-packages
* Add the cross-python and python build dependency.
* Remove the python-build host dependency.
* Bump the build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
