### PR TITLE
MNT: Build against global pinning fastjet-cxx 

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -14,6 +14,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma9
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '19'
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - vs2022
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - vs2022
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - vs2022
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - vs2022
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -8,6 +8,8 @@ cxx_compiler:
 - vs2022
 fastjet_contrib:
 - '1.103'
+fastjet_cxx:
+- '3.5'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 526c0538d3f0d2922795266bce0027a0719be327c815b7c3f54ebdcee635f79e
 
 build:
-  number: 2
+  number: 3
   script:
     - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation -C"cmake.define.SKHEPFJ_USE_INSTALLED_FASTJET=ON" -C"cmake.define.SKHEPFJ_USE_INSTALLED_FASTJET_CONTRIB=ON" -C"cmake.define.SKHEPFJ_PASSTHRU_FASTJET_SWIG=ON"
 
@@ -28,6 +28,7 @@ requirements:
     - if: unix
       then: make
   host:
+    - fastjet-cxx  # pick up global pinning
     - fastjet-cxx-python
     - fastjet-contrib
     - pip


### PR DESCRIPTION
* List `fastjet-cxx` explicilty as a host requirement, even though `fastjet-cxx-python` already pulls it in, so that it will pick up the global pinning.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
